### PR TITLE
[feature] def assert_false/1

### DIFF
--- a/lib/simple_assert.ex
+++ b/lib/simple_assert.ex
@@ -32,17 +32,17 @@ defmodule SimpleAssert do
 
   ## Examples
 
-      iex> SimpleAssert.exists_false(false)
+      iex> SimpleAssert.assert_false(false)
       :ok
 
-      iex> SimpleAssert.exists_false(nil)
+      iex> SimpleAssert.assert_false(nil)
       :ok
 
-      iex> SimpleAssert.exists_false(:unexpected_result)
+      iex> SimpleAssert.assert_false(:unexpected_result)
       ** (ArgumentError) assertion failed!
   """
-  @spec exists_false(any()) :: :ok | none()
-  def exists_false(e) do
+  @spec assert_false(any()) :: :ok | none()
+  def assert_false(e) do
     cond do
       e == false -> :ok
       e == nil -> :ok

--- a/lib/simple_assert.ex
+++ b/lib/simple_assert.ex
@@ -24,4 +24,29 @@ defmodule SimpleAssert do
       raise ArgumentError, "assertion failed!"
     end
   end
+
+  @doc """
+  Asserts the `e` is `false` or `nil`.
+
+  If it succeeds, it returns `:ok`. Raises an error otherwise.
+
+  ## Examples
+
+      iex> SimpleAssert.exists_false(false)
+      :ok
+
+      iex> SimpleAssert.exists_false(nil)
+      :ok
+
+      iex> SimpleAssert.exists_false(:unexpected_result)
+      ** (ArgumentError) assertion failed!
+  """
+  @spec exists_false(any()) :: :ok | none()
+  def exists_false(e) do
+    cond do
+      e == false -> :ok
+      e == nil -> :ok
+      true -> raise ArgumentError, "assertion failed!"
+    end
+  end
 end

--- a/test/simple_assert/assert_false_test.exs
+++ b/test/simple_assert/assert_false_test.exs
@@ -1,20 +1,20 @@
-defmodule ExistsFalseTest do
+defmodule AssertFalseTest do
   use ExUnit.Case
   doctest SimpleAssert
 
   test "When paramater evaluates to `false`, then `:ok`." do
-    assert SimpleAssert.exists_false(false) == :ok
+    assert SimpleAssert.assert_false(false) == :ok
   end
 
   test "When paramater evaluates to `true`, then `ArgumentError`." do
     assert_raise ArgumentError, fn ->
-      SimpleAssert.exists_false(true) == :ok
+      SimpleAssert.assert_false(true) == :ok
     end
   end
 
   test "When paramater evaluates to any strings, then `ArgumentError`." do
     assert_raise ArgumentError, fn ->
-      SimpleAssert.exists_false("foo bar")
+      SimpleAssert.assert_false("foo bar")
     end
   end
 end

--- a/test/simple_assert/exists_false_test.exs
+++ b/test/simple_assert/exists_false_test.exs
@@ -1,0 +1,20 @@
+defmodule ExistsFalseTest do
+  use ExUnit.Case
+  doctest SimpleAssert
+
+  test "When paramater evaluates to `false`, then `:ok`." do
+    assert SimpleAssert.exists_false(false) == :ok
+  end
+
+  test "When paramater evaluates to `true`, then `ArgumentError`." do
+    assert_raise ArgumentError, fn ->
+      SimpleAssert.exists_false(true) == :ok
+    end
+  end
+
+  test "When paramater evaluates to any strings, then `ArgumentError`." do
+    assert_raise ArgumentError, fn ->
+      SimpleAssert.exists_false("foo bar")
+    end
+  end
+end


### PR DESCRIPTION
# Overview

Added the feature `def assert_false/1`.

# Specification

Asserts the argument is `false` or `nil`.

- If it succeeds, it returns `:ok`.
- Raises an error otherwise.

  ```elixir
  ** (ArgumentError) assertion failed!
  ```

# Confirmation

- [x] `mix dialyzer` passed.
- [x] `mix test` passed.
